### PR TITLE
Fix: Generative case broken on accounts only holding SOL/Lamports

### DIFF
--- a/sol-did/src/DidSolService.ts
+++ b/sol-did/src/DidSolService.ts
@@ -164,9 +164,23 @@ export class DidSolService {
   }
 
   async getDidAccount(): Promise<DidDataAccount | null> {
-    return (await this._program.account.didAccount.fetchNullable(
+    // TODO: this should be reverted as soon as https://github.com/coral-xyz/anchor/issues/2172 is fixed
+    const accountInfo = await this._program.account.didAccount.getAccountInfo(
       this._didDataAccount
-    )) as DidDataAccount;
+    );
+    if (accountInfo === null || accountInfo.data.length === 0) {
+      return null;
+    }
+
+    return this._program.account.didAccount.coder.accounts.decode<DidDataAccount>(
+      'DidAccount', // TODO: from "this._program.account.didAccount._idlAccount.name" - How to get this officially?
+      accountInfo.data
+    );
+
+    // Original Code
+    // return (await this._program.account.didAccount.fetchNullable(
+    //   this._didDataAccount
+    // )) as DidDataAccount;
   }
 
   async getDidAccountWithSize(

--- a/sol-did/tests/suite-resolve/resolve.ts
+++ b/sol-did/tests/suite-resolve/resolve.ts
@@ -112,6 +112,22 @@ describe('sol-did resolve and migrate operations', () => {
     );
   });
 
+  it('can successfully resolve a generative DID if the PDA has a balance.', async () => {
+    const solKey = web3.Keypair.generate();
+    const localService = await DidSolService.buildFromAnchor(
+      program,
+      DidSolIdentifier.create(solKey.publicKey, TEST_CLUSTER),
+      programProvider
+    );
+
+    await airdrop(programProvider.connection, localService.didDataAccount);
+
+    const didDoc = await localService.resolve();
+    expect(didDoc).to.deep.equal(
+      getGeneratedDidDocument(solKey.publicKey.toBase58(), 'did:sol:localnet:')
+    );
+  });
+
   it('can successfully resolve a DID', async () => {
     const didDoc = await service.resolve();
     expect(didDoc).to.deep.equal(didDocComplete);


### PR DESCRIPTION
This fixes:

```
Error: Invalid account discriminator
    at BorshAccountsCoder.decode (/Users/mriedel/Development/identity-com/sol-did/cli/node_modules/@project-serum/anchor/src/coder/borsh/accounts.ts:61:13)
    at AccountClient.fetchNullable (/Users/mriedel/Development/identity-com/sol-did/cli/node_modules/@project-serum/anchor/src/program/namespace/account.ts:140:33)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

for PDA accounts only holding SOL/lamports (and no data). Source fix will be committed to anchor.