### PR TITLE
Streamlined Service builder Interface

### DIFF
--- a/.github/workflows/uinresolver-driver.yml
+++ b/.github/workflows/uinresolver-driver.yml
@@ -12,6 +12,8 @@ jobs:
     strategy:
       matrix:
         node: ['16.x']
+        rust: [ '1.61' ]
+        solana: [ 'v1.10.29' ]
         os: [ubuntu-latest]
 
     defaults:
@@ -21,6 +23,34 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+
+      - name: Use Rust ${{ matrix.rust }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+          profile: minimal
+
+      - name: Cache build dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./sol-did/target
+          key: cargo-build-${{ hashFiles('sol-did/Cargo.lock') }}
+
+      - name: Cache Solana version
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache
+          key: solana-${{ matrix.solana }}
+
+      - name: Install Solana
+        run: |
+          sh -c "$(curl -sSfL https://release.solana.com/${{ matrix.solana }}/install)"
+          echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v1

--- a/drivers/uniresolver/package.json
+++ b/drivers/uniresolver/package.json
@@ -19,6 +19,7 @@
     "build": "tsdx build",
     "postbuild": "mkdir dist/api && cp src/api/openapi.yml dist/api/",
     "test": "tsdx test",
+    "pretest": "(cd ../../sol-did && yarn && yarn build && yarn link) && yarn link @identity.com/sol-did-client",
     "lint": "tsdx lint --maxWarnings 0",
     "prepublishOnly": "yarn build",
     "dev": "ts-node-dev src/index.ts",
@@ -43,7 +44,7 @@
     "typescript": "^4.1.5"
   },
   "dependencies": {
-    "@identity.com/sol-did-client": "3.0.0-beta11",
+    "@identity.com/sol-did-client": "^3.0.1-beta1",
     "cors": "^2.8.5",
     "did-resolver": "^3.0.1",
     "oas3-tools": "^2.2.3"

--- a/drivers/uniresolver/src/service/Deactivator.ts
+++ b/drivers/uniresolver/src/service/Deactivator.ts
@@ -1,11 +1,8 @@
 import {
-  DidSolService,
-  DidSolIdentifier,
   makeKeypair,
-  CustomClusterUrlConfig,
 } from '@identity.com/sol-did-client';
 import { DeactivateRequest, DeactivateState } from './DefaultService';
-import { getConfig } from '../config/config';
+import { buildService } from "../utils";
 
 export const deactivate = async (
   request: DeactivateRequest
@@ -15,15 +12,8 @@ export const deactivate = async (
   if (!payer)
     throw new Error('Missing payer information- add a request secret');
 
-  const didSolIdentifier = DidSolIdentifier.parse(request.identifier);
+  const service = await buildService(request.identifier);
 
-  const config = await getConfig();
-  let clusterConfig: CustomClusterUrlConfig | undefined;
-  if (config) {
-    clusterConfig = config.solanaRpcNodes;
-  }
-
-  const service = await DidSolService.build(didSolIdentifier, clusterConfig);
 
   const payerKeypair = makeKeypair(payer);
   const authorityKeypair = owner ? makeKeypair(owner) : payerKeypair;

--- a/drivers/uniresolver/src/service/Deactivator.ts
+++ b/drivers/uniresolver/src/service/Deactivator.ts
@@ -1,8 +1,6 @@
-import {
-  makeKeypair,
-} from '@identity.com/sol-did-client';
+import { makeKeypair } from '@identity.com/sol-did-client';
 import { DeactivateRequest, DeactivateState } from './DefaultService';
-import { buildService } from "../utils";
+import { buildService } from '../utils';
 
 export const deactivate = async (
   request: DeactivateRequest
@@ -13,7 +11,6 @@ export const deactivate = async (
     throw new Error('Missing payer information- add a request secret');
 
   const service = await buildService(request.identifier);
-
 
   const payerKeypair = makeKeypair(payer);
   const authorityKeypair = owner ? makeKeypair(owner) : payerKeypair;

--- a/drivers/uniresolver/src/service/DefaultService.ts
+++ b/drivers/uniresolver/src/service/DefaultService.ts
@@ -3,7 +3,7 @@ import { ResponseContent } from '../utils';
 import { DIDDocument, VerificationMethod } from 'did-resolver';
 import { deactivate } from './Deactivator';
 import { update } from './Updater';
-import { buildService } from "../utils";
+import { buildService } from '../utils';
 
 type ResolutionResult = {
   didDocument: DIDDocument;
@@ -117,7 +117,6 @@ export const resolveDID = async (
   identifier: string,
   _accept: string
 ): Promise<ResponseContent<ResolutionResult>> => {
-
   const service = await buildService(identifier);
   const didDocument = await service.resolve();
 

--- a/drivers/uniresolver/src/service/DefaultService.ts
+++ b/drivers/uniresolver/src/service/DefaultService.ts
@@ -1,14 +1,9 @@
 import { register } from './Registrar';
-import { ResponseContent } from '../utils/writer';
+import { ResponseContent } from '../utils';
 import { DIDDocument, VerificationMethod } from 'did-resolver';
 import { deactivate } from './Deactivator';
 import { update } from './Updater';
-import {
-  CustomClusterUrlConfig,
-  DidSolIdentifier,
-  DidSolService,
-} from '@identity.com/sol-did-client';
-import { getConfig } from '../config/config';
+import { buildService } from "../utils";
 
 type ResolutionResult = {
   didDocument: DIDDocument;
@@ -122,14 +117,8 @@ export const resolveDID = async (
   identifier: string,
   _accept: string
 ): Promise<ResponseContent<ResolutionResult>> => {
-  const config = await getConfig();
-  let clusterConfig: CustomClusterUrlConfig | undefined;
-  if (config) {
-    clusterConfig = config.solanaRpcNodes;
-  }
 
-  const didSolIdentifier = DidSolIdentifier.parse(identifier);
-  const service = await DidSolService.build(didSolIdentifier, clusterConfig);
+  const service = await buildService(identifier);
   const didDocument = await service.resolve();
 
   if (didDocument) {

--- a/drivers/uniresolver/src/service/Registrar.ts
+++ b/drivers/uniresolver/src/service/Registrar.ts
@@ -11,7 +11,7 @@ import {
 } from '@identity.com/sol-did-client';
 import { Keypair } from '@solana/web3.js';
 import { encode } from 'bs58';
-import { buildService } from "../utils";
+import { buildService } from '../utils';
 
 export const register = async (
   request: RegisterRequest

--- a/drivers/uniresolver/src/service/Registrar.ts
+++ b/drivers/uniresolver/src/service/Registrar.ts
@@ -5,15 +5,13 @@ import {
 } from './DefaultService';
 import {
   clusterFromString,
-  CustomClusterUrlConfig,
   DidSolDocument,
   DidSolIdentifier,
-  DidSolService,
   makeKeypair,
 } from '@identity.com/sol-did-client';
 import { Keypair } from '@solana/web3.js';
 import { encode } from 'bs58';
-import { getConfig } from '../config/config';
+import { buildService } from "../utils";
 
 export const register = async (
   request: RegisterRequest
@@ -33,13 +31,8 @@ export const register = async (
     cluster
   );
 
-  const config = await getConfig();
-  let clusterConfig: CustomClusterUrlConfig | undefined;
-  if (config) {
-    clusterConfig = config.solanaRpcNodes;
-  }
+  const service = await buildService(didSolIdentifier.toString());
 
-  const service = await DidSolService.build(didSolIdentifier, clusterConfig);
   const doc = await DidSolDocument.fromDoc(request.didDocument);
   await service
     .updateFromDoc(doc)

--- a/drivers/uniresolver/src/service/Updater.ts
+++ b/drivers/uniresolver/src/service/Updater.ts
@@ -1,12 +1,9 @@
 import { UpdateRequest, UpdateState } from './DefaultService';
 import {
-  CustomClusterUrlConfig,
   DidSolDocument,
-  DidSolIdentifier,
-  DidSolService,
   makeKeypair,
 } from '@identity.com/sol-did-client';
-import { getConfig } from '../config/config';
+import { buildService } from "../utils";
 
 export const update = async (request: UpdateRequest): Promise<UpdateState> => {
   const payer = request.secret?.payer || process.env.PAYER;
@@ -18,15 +15,8 @@ export const update = async (request: UpdateRequest): Promise<UpdateState> => {
     ? makeKeypair(request.secret.owner)
     : payerKeypair;
 
-  const didSolIdentifier = DidSolIdentifier.parse(request.identifier);
+  const service = await buildService(request.identifier);
 
-  const config = await getConfig();
-  let clusterConfig: CustomClusterUrlConfig | undefined;
-  if (config) {
-    clusterConfig = config.solanaRpcNodes;
-  }
-
-  const service = await DidSolService.build(didSolIdentifier, clusterConfig);
   const doc = await DidSolDocument.fromDoc(request.didDocument);
   await service
     .updateFromDoc(doc)

--- a/drivers/uniresolver/src/service/Updater.ts
+++ b/drivers/uniresolver/src/service/Updater.ts
@@ -1,9 +1,6 @@
 import { UpdateRequest, UpdateState } from './DefaultService';
-import {
-  DidSolDocument,
-  makeKeypair,
-} from '@identity.com/sol-did-client';
-import { buildService } from "../utils";
+import { DidSolDocument, makeKeypair } from '@identity.com/sol-did-client';
+import { buildService } from '../utils';
 
 export const update = async (request: UpdateRequest): Promise<UpdateState> => {
   const payer = request.secret?.payer || process.env.PAYER;

--- a/drivers/uniresolver/src/utils/index.ts
+++ b/drivers/uniresolver/src/utils/index.ts
@@ -1,14 +1,17 @@
-import { getConfig } from "../config/config";
+import { getConfig } from '../config/config';
 import {
   CustomClusterUrlConfig,
-  DidSolIdentifier, DidSolService,
+  DidSolIdentifier,
+  DidSolService,
   getConnectionByCluster,
-  SOLANA_COMMITMENT
-} from "@identity.com/sol-did-client";
+  SOLANA_COMMITMENT,
+} from '@identity.com/sol-did-client';
 
 export * from './writer';
 
-export const buildService =  async (identifier: string): Promise<DidSolService> => {
+export const buildService = async (
+  identifier: string
+): Promise<DidSolService> => {
   const config = await getConfig();
   let clusterConfig: CustomClusterUrlConfig | undefined;
   if (config) {
@@ -18,9 +21,13 @@ export const buildService =  async (identifier: string): Promise<DidSolService> 
   const didSolIdentifier = DidSolIdentifier.parse(identifier);
 
   // get connection from config
-  const connection = getConnectionByCluster(didSolIdentifier.clusterType, SOLANA_COMMITMENT, clusterConfig);
+  const connection = getConnectionByCluster(
+    didSolIdentifier.clusterType,
+    SOLANA_COMMITMENT,
+    clusterConfig
+  );
 
   return DidSolService.build(didSolIdentifier, {
     connection,
   });
-}
+};

--- a/drivers/uniresolver/src/utils/index.ts
+++ b/drivers/uniresolver/src/utils/index.ts
@@ -1,0 +1,26 @@
+import { getConfig } from "../config/config";
+import {
+  CustomClusterUrlConfig,
+  DidSolIdentifier, DidSolService,
+  getConnectionByCluster,
+  SOLANA_COMMITMENT
+} from "@identity.com/sol-did-client";
+
+export * from './writer';
+
+export const buildService =  async (identifier: string): Promise<DidSolService> => {
+  const config = await getConfig();
+  let clusterConfig: CustomClusterUrlConfig | undefined;
+  if (config) {
+    clusterConfig = config.solanaRpcNodes;
+  }
+
+  const didSolIdentifier = DidSolIdentifier.parse(identifier);
+
+  // get connection from config
+  const connection = getConnectionByCluster(didSolIdentifier.clusterType, SOLANA_COMMITMENT, clusterConfig);
+
+  return DidSolService.build(didSolIdentifier, {
+    connection,
+  });
+}

--- a/sol-did/src/DidSolService.ts
+++ b/sol-did/src/DidSolService.ts
@@ -27,7 +27,8 @@ import {
 } from '@solana/web3.js';
 import { DIDDocument } from 'did-resolver';
 import {
-  DidDataAccount, DidSolServiceOptions,
+  DidDataAccount,
+  DidSolServiceOptions,
   DidSolUpdateArgs,
   EthSigner,
   Service,
@@ -37,10 +38,7 @@ import {
 } from './lib/types';
 import { DEFAULT_KEY_ID, INITIAL_MIN_ACCOUNT_SIZE } from './lib/const';
 import { DidSolDocument } from './DidSolDocument';
-import {
-  ExtendedCluster,
-  getConnectionByCluster,
-} from './lib/connection';
+import { ExtendedCluster, getConnectionByCluster } from './lib/connection';
 import { DidSolIdentifier } from './DidSolIdentifier';
 import {
   closeAccount,
@@ -63,14 +61,17 @@ export class DidSolService {
 
   static async build(
     identifier: DidSolIdentifier,
-    options: DidSolServiceOptions,
+    options: DidSolServiceOptions
   ): Promise<DidSolService> {
     const wallet = options.wallet || new NonSigningWallet();
-    const confirmOptions = options.confirmOptions || AnchorProvider.defaultOptions();
-    const connection = options.connection || getConnectionByCluster(
-      identifier.clusterType,
-      confirmOptions.preflightCommitment,
-    );
+    const confirmOptions =
+      options.confirmOptions || AnchorProvider.defaultOptions();
+    const connection =
+      options.connection ||
+      getConnectionByCluster(
+        identifier.clusterType,
+        confirmOptions.preflightCommitment
+      );
 
     // Note, DidSolService never signs, so provider does not need a valid Wallet or confirmOptions.
     const provider = new AnchorProvider(connection, wallet, confirmOptions);
@@ -152,7 +153,9 @@ export class DidSolService {
     const [legacyDidDataAccount] = await findLegacyProgramAddress(didAuthority);
 
     if (this._cluster !== identifier.clusterType) {
-      throw new Error('Cannot build a service from an existing service with a different cluster');
+      throw new Error(
+        'Cannot build a service from an existing service with a different cluster'
+      );
     }
 
     // reuse existing program

--- a/sol-did/src/DidSolService.ts
+++ b/sol-did/src/DidSolService.ts
@@ -27,7 +27,7 @@ import {
 } from '@solana/web3.js';
 import { DIDDocument } from 'did-resolver';
 import {
-  DidDataAccount,
+  DidDataAccount, DidSolServiceOptions,
   DidSolUpdateArgs,
   EthSigner,
   Service,
@@ -38,7 +38,6 @@ import {
 import { DEFAULT_KEY_ID, INITIAL_MIN_ACCOUNT_SIZE } from './lib/const';
 import { DidSolDocument } from './DidSolDocument';
 import {
-  CustomClusterUrlConfig,
   ExtendedCluster,
   getConnectionByCluster,
 } from './lib/connection';
@@ -64,17 +63,17 @@ export class DidSolService {
 
   static async build(
     identifier: DidSolIdentifier,
-    customConfig?: CustomClusterUrlConfig,
-    wallet: Wallet = new NonSigningWallet(),
-    opts: ConfirmOptions = AnchorProvider.defaultOptions()
+    options: DidSolServiceOptions,
   ): Promise<DidSolService> {
-    const _connection = getConnectionByCluster(
+    const wallet = options.wallet || new NonSigningWallet();
+    const confirmOptions = options.confirmOptions || AnchorProvider.defaultOptions();
+    const connection = options.connection || getConnectionByCluster(
       identifier.clusterType,
-      opts.preflightCommitment,
-      customConfig
+      confirmOptions.preflightCommitment,
     );
+
     // Note, DidSolService never signs, so provider does not need a valid Wallet or confirmOptions.
-    const provider = new AnchorProvider(_connection, wallet, opts);
+    const provider = new AnchorProvider(connection, wallet, confirmOptions);
 
     const program = await fetchProgram(provider);
     const [didDataAccount] = await findProgramAddress(identifier.authority);
@@ -139,17 +138,22 @@ export class DidSolService {
 
   /**
    * Build a Service from an existing Service. Note, this will not allow to generate the service with a different cluster.
-   * @param didAuthority
+   * @param identifier
    * @param wallet
    * @param opts
    */
   async build(
-    didAuthority: PublicKey,
+    identifier: DidSolIdentifier,
     wallet?: Wallet,
     opts?: ConfirmOptions
   ): Promise<DidSolService> {
+    const didAuthority = identifier.authority;
     const [didDataAccount] = await findProgramAddress(didAuthority);
     const [legacyDidDataAccount] = await findLegacyProgramAddress(didAuthority);
+
+    if (this._cluster !== identifier.clusterType) {
+      throw new Error('Cannot build a service from an existing service with a different cluster');
+    }
 
     // reuse existing program
     return new DidSolService(

--- a/sol-did/src/lib/types.ts
+++ b/sol-did/src/lib/types.ts
@@ -1,5 +1,10 @@
 import { BN, web3 } from '@project-serum/anchor';
-import { ConfirmOptions, Connection, PublicKey, Transaction } from '@solana/web3.js';
+import {
+  ConfirmOptions,
+  Connection,
+  PublicKey,
+  Transaction,
+} from '@solana/web3.js';
 import { VerificationMethod as DidVerificationMethod } from 'did-resolver';
 import { ExtendedCluster } from './connection';
 
@@ -96,4 +101,4 @@ export type DidSolServiceOptions = {
   connection?: Connection;
   wallet?: Wallet;
   confirmOptions?: ConfirmOptions;
-}
+};

--- a/sol-did/src/lib/types.ts
+++ b/sol-did/src/lib/types.ts
@@ -1,5 +1,5 @@
 import { BN, web3 } from '@project-serum/anchor';
-import { PublicKey, Transaction } from '@solana/web3.js';
+import { ConfirmOptions, Connection, PublicKey, Transaction } from '@solana/web3.js';
 import { VerificationMethod as DidVerificationMethod } from 'did-resolver';
 import { ExtendedCluster } from './connection';
 
@@ -90,4 +90,10 @@ export interface Wallet {
   signTransaction(tx: Transaction): Promise<Transaction>;
   signAllTransactions(txs: Transaction[]): Promise<Transaction[]>;
   publicKey: PublicKey;
+}
+
+export type DidSolServiceOptions = {
+  connection?: Connection;
+  wallet?: Wallet;
+  confirmOptions?: ConfirmOptions;
 }

--- a/sol-did/tests/suite-resolve/resolve.ts
+++ b/sol-did/tests/suite-resolve/resolve.ts
@@ -164,7 +164,8 @@ describe('sol-did resolve and migrate operations', () => {
     expect(await service.isMigratable()).to.be.false;
 
     const solKey = web3.Keypair.generate();
-    const genDidService = await service.build(solKey.publicKey);
+    const identifier = DidSolIdentifier.create(solKey.publicKey, TEST_CLUSTER);
+    const genDidService = await service.build(identifier);
 
     return expect(
       genDidService


### PR DESCRIPTION
> :warning: **This would cause a breaking change from v3.0.0**

Changed `DidSolService.build` to

```
  static async build(
    identifier: DidSolIdentifier,
    options: DidSolServiceOptions,
  ): Promise<DidSolService> {
```

with
```
export type DidSolServiceOptions = {
  connection?: Connection;
  wallet?: Wallet;
  confirmOptions?: ConfirmOptions;
}
```

that means
- all options have been put into a dedicated type interface `DidSolServiceOptions`
- customClusterConfig is gone and was replace by an optional `connection`
- Uniresolver container was updated to create the appropriate `connection` OUTSIDE of the service builder.
 