### PR TITLE
support inferred capability_invocation on migrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Legacy DID Migration did not work for "inferred" CapabilityInvocation on the "default" VerificationMethod
+- `migrate()` operation did not close the legacy account after migration when an legacyAuthority was specified
 
 ### Security
 

--- a/sol-did/client/packages/core/src/utils/DidSolTransactionBuilder.ts
+++ b/sol-did/client/packages/core/src/utils/DidSolTransactionBuilder.ts
@@ -286,10 +286,12 @@ export abstract class DidSolTransactionBuilder {
       instructionChain.push(this._closeInstruction);
     }
 
-    this.clearInstructions();
-
     // ethSign
-    return this.ethSignInstructions(instructionChain);
+    const finalInstructions = await this.ethSignInstructions(instructionChain);
+
+    // needs to be the last method.
+    this.clearInstructions();
+    return finalInstructions;
   }
 
   async transaction(): Promise<Transaction> {

--- a/sol-did/programs/sol-did/src/legacy/legacy_did_account.rs
+++ b/sol-did/programs/sol-did/src/legacy/legacy_did_account.rs
@@ -143,6 +143,11 @@ impl LegacyDidAccount {
             flags |= VerificationMethodFlags::KEY_AGREEMENT;
         }
 
+        // special case for inferred "capability_invocation" verification method
+        if self.capability_invocation.is_empty() && vm_fragment == VM_DEFAULT_FRAGMENT_NAME {
+            flags |= VerificationMethodFlags::CAPABILITY_INVOCATION;
+        }
+
         flags
     }
 


### PR DESCRIPTION
Using migrate could lead to an unusable DID account, when the `default` VerificationMethod hat the CapabilityInvocation inferred.

Also fixed a related issue, where the legacy `close` instruction was not properly created.