### PR TITLE
updated find_authority and is_authority interfaces to not perform secp256k1 validation anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Provided `pub fn eth_verify_message` as a public utility method to verify eth signed messages.
 
 ### Changed
+- Updated `is_authority` and `find_authority` function signatures to not perform secp256k1 verification anymore.
 
 ### Deprecated
 

--- a/sol-did/client/packages/idl/src/sol_did.ts
+++ b/sol-did/client/packages/idl/src/sol_did.ts
@@ -686,6 +686,11 @@ export type SolDid = {
       "code": 6010,
       "name": "InvalidControllerChain",
       "msg": "Invalid chain of controlling DidAccounts"
+    },
+    {
+      "code": 6011,
+      "name": "ErrorValidatingSecp256k1Signature",
+      "msg": "An error occurred while validating Secp256k1 signature"
     }
   ]
 };
@@ -1378,6 +1383,11 @@ export const IDL: SolDid = {
       "code": 6010,
       "name": "InvalidControllerChain",
       "msg": "Invalid chain of controlling DidAccounts"
+    },
+    {
+      "code": 6011,
+      "name": "ErrorValidatingSecp256k1Signature",
+      "msg": "An error occurred while validating Secp256k1 signature"
     }
   ]
 };

--- a/sol-did/programs/sol-did/src/errors.rs
+++ b/sol-did/programs/sol-did/src/errors.rs
@@ -24,4 +24,6 @@ pub enum DidSolError {
     ConversionError,
     #[msg("Invalid chain of controlling DidAccounts")]
     InvalidControllerChain,
+    #[msg("An error occurred while validating Secp256k1 signature")]
+    ErrorValidatingSecp256k1Signature,
 }

--- a/sol-did/programs/sol-did/src/instructions/add_service.rs
+++ b/sol-did/programs/sol-did/src/instructions/add_service.rs
@@ -32,7 +32,7 @@ pub struct AddService<'info> {
     mut,
     seeds = [DID_ACCOUNT_SEED.as_bytes(), did_data.initial_verification_method.key_data.as_ref()],
     bump = did_data.bump,
-    constraint = did_data.find_authority(&authority.key(), &signed_message(&service, allow_overwrite), eth_signature.as_ref(), None).is_some(),
+    constraint = did_data.find_authority_constraint(&authority.key(), &signed_message(&service, allow_overwrite), eth_signature.as_ref(), None).is_some(),
     )]
     pub did_data: Account<'info, DidAccount>,
     pub authority: Signer<'info>,

--- a/sol-did/programs/sol-did/src/instructions/add_verification_method.rs
+++ b/sol-did/programs/sol-did/src/instructions/add_verification_method.rs
@@ -29,7 +29,7 @@ pub struct AddVerificationMethod<'info> {
         mut,
         seeds = [DID_ACCOUNT_SEED.as_bytes(), did_data.initial_verification_method.key_data.as_ref()],
         bump = did_data.bump,
-        constraint = did_data.find_authority(&authority.key(), &verification_method.try_to_vec().unwrap(), eth_signature.as_ref(), None).is_some(),
+        constraint = did_data.find_authority_constraint(&authority.key(), &verification_method.try_to_vec().unwrap(), eth_signature.as_ref(), None).is_some(),
     )]
     pub did_data: Account<'info, DidAccount>,
     pub authority: Signer<'info>,

--- a/sol-did/programs/sol-did/src/instructions/close.rs
+++ b/sol-did/programs/sol-did/src/instructions/close.rs
@@ -19,7 +19,7 @@ pub struct Close<'info> {
         close = destination,
         seeds = [DID_ACCOUNT_SEED.as_bytes(), did_data.initial_verification_method.key_data.as_ref()],
         bump = did_data.bump,
-        constraint = did_data.find_authority(&authority.key(), &[], eth_signature.as_ref(), None).is_some(),
+        constraint = did_data.find_authority_constraint(&authority.key(), &[], eth_signature.as_ref(), None).is_some(),
     )]
     pub did_data: Account<'info, DidAccount>,
     pub authority: Signer<'info>,

--- a/sol-did/programs/sol-did/src/instructions/remove_service.rs
+++ b/sol-did/programs/sol-did/src/instructions/remove_service.rs
@@ -29,7 +29,7 @@ pub struct RemoveService<'info> {
         mut,
         seeds = [DID_ACCOUNT_SEED.as_bytes(), did_data.initial_verification_method.key_data.as_ref()],
         bump = did_data.bump,
-        constraint = did_data.find_authority(&authority.key(), &service_id.try_to_vec().unwrap(), eth_signature.as_ref(), None).is_some(),
+        constraint = did_data.find_authority_constraint(&authority.key(), &service_id.try_to_vec().unwrap(), eth_signature.as_ref(), None).is_some(),
     )]
     pub did_data: Account<'info, DidAccount>,
     pub authority: Signer<'info>,

--- a/sol-did/programs/sol-did/src/instructions/remove_verification_method.rs
+++ b/sol-did/programs/sol-did/src/instructions/remove_verification_method.rs
@@ -31,7 +31,7 @@ pub struct RemoveVerificationMethod<'info> {
         mut,
         seeds = [DID_ACCOUNT_SEED.as_bytes(), did_data.initial_verification_method.key_data.as_ref()],
         bump = did_data.bump,
-        constraint = did_data.find_authority(&authority.key(), &fragment.try_to_vec().unwrap(), eth_signature.as_ref(), None).is_some(),
+        constraint = did_data.find_authority_constraint(&authority.key(), &fragment.try_to_vec().unwrap(), eth_signature.as_ref(), None).is_some(),
     )]
     pub did_data: Account<'info, DidAccount>,
     pub authority: Signer<'info>,

--- a/sol-did/programs/sol-did/src/instructions/resize.rs
+++ b/sol-did/programs/sol-did/src/instructions/resize.rs
@@ -25,7 +25,7 @@ pub struct Resize<'info> {
         realloc = TryInto::<usize>::try_into(size).unwrap(),
         realloc::payer = payer,
         realloc::zero = false,
-        constraint = did_data.find_authority(&authority.key(), &size.to_le_bytes(), eth_signature.as_ref(), None).is_some(),
+        constraint = did_data.find_authority_constraint(&authority.key(), &size.to_le_bytes(), eth_signature.as_ref(), None).is_some(),
     )]
     pub did_data: Account<'info, DidAccount>,
     #[account(mut)]

--- a/sol-did/programs/sol-did/src/instructions/set_controllers.rs
+++ b/sol-did/programs/sol-did/src/instructions/set_controllers.rs
@@ -25,7 +25,7 @@ pub struct SetControllers<'info> {
         mut,
         seeds = [DID_ACCOUNT_SEED.as_bytes(), did_data.initial_verification_method.key_data.as_ref()],
         bump = did_data.bump,
-        constraint = did_data.find_authority(&authority.key(), &set_controllers_arg.try_to_vec().unwrap(), eth_signature.as_ref(), None).is_some(),
+        constraint = did_data.find_authority_constraint(&authority.key(), &set_controllers_arg.try_to_vec().unwrap(), eth_signature.as_ref(), None).is_some(),
     )]
     pub did_data: Account<'info, DidAccount>,
     pub authority: Signer<'info>,

--- a/sol-did/programs/sol-did/src/instructions/set_vm_flags.rs
+++ b/sol-did/programs/sol-did/src/instructions/set_vm_flags.rs
@@ -33,7 +33,7 @@ pub struct SetVmFlagsMethod<'info> {
         mut,
         seeds = [DID_ACCOUNT_SEED.as_bytes(), did_data.initial_verification_method.key_data.as_ref()],
         bump = did_data.bump,
-        constraint = did_data.find_authority(&authority.key(), &flags_vm.try_to_vec().unwrap(), eth_signature.as_ref(), flags_vm.get_filter_fragment()).is_some(),
+        constraint = did_data.find_authority_constraint(&authority.key(), &flags_vm.try_to_vec().unwrap(), eth_signature.as_ref(), flags_vm.get_filter_fragment()).is_some(),
     )]
     pub did_data: Account<'info, DidAccount>,
     pub authority: Signer<'info>,

--- a/sol-did/programs/sol-did/src/instructions/update.rs
+++ b/sol-did/programs/sol-did/src/instructions/update.rs
@@ -28,7 +28,7 @@ pub struct Update<'info> {
         mut,
         seeds = [b"did-account", did_data.initial_verification_method.key_data.as_ref()],
         bump = did_data.bump,
-        constraint = did_data.find_authority(&authority.key(), &update_arg.try_to_vec().unwrap(), eth_signature.as_ref(), None).is_some()
+        constraint = did_data.find_authority_constraint(&authority.key(), &update_arg.try_to_vec().unwrap(), eth_signature.as_ref(), None).is_some()
     )]
     pub did_data: Account<'info, DidAccount>,
     pub authority: Signer<'info>,

--- a/sol-did/programs/sol-did/src/integrations/is_authority.rs
+++ b/sol-did/programs/sol-did/src/integrations/is_authority.rs
@@ -59,19 +59,11 @@ pub fn is_authority(
     let did_to_check_authority = controller_chain.last();
     let authority_exists = if let Some(did_to_check_authority) = did_to_check_authority {
         did_to_check_authority
-            .find_authority(
-                key,
-                filter_types,
-                filter_fragment,
-            )
+            .find_authority(key, filter_types, filter_fragment)
             .is_some()
     } else {
         did_data
-            .find_authority(
-                key,
-                filter_types,
-                filter_fragment,
-            )
+            .find_authority(key, filter_types, filter_fragment)
             .is_some()
     };
 
@@ -139,7 +131,8 @@ mod test {
             Pubkey::from_str("3spWJgYRKqrZnBkgv6dwjohKG5x3ZBEdxoLxuC2LfwD2").unwrap();
         let expected_bump = 255;
 
-        let did_account_pubkey = derive_did_account_with_bump(&authority.to_bytes(), expected_bump).unwrap();
+        let did_account_pubkey =
+            derive_did_account_with_bump(&authority.to_bytes(), expected_bump).unwrap();
 
         assert_eq!(did_account_pubkey, expected_did_account);
     }

--- a/sol-did/programs/sol-did/src/state/did_account.rs
+++ b/sol-did/programs/sol-did/src/state/did_account.rs
@@ -210,7 +210,7 @@ impl DidAccount {
         filter_types: Option<&[VerificationMethodType]>,
         filter_fragment: Option<&String>,
     ) -> Option<&VerificationMethod> {
-        msg!("Checking if key {:?} is an authority", key,);
+        // msg!("Checking if key {:?} is an authority", key,);
         self.verification_methods(
             filter_types,
             Some(VerificationMethodFlags::CAPABILITY_INVOCATION),

--- a/sol-did/programs/sol-did/src/utils.rs
+++ b/sol-did/programs/sol-did/src/utils.rs
@@ -1,6 +1,8 @@
 use crate::constants::DID_SOL_PREFIX;
 use solana_program::keccak;
-use solana_program::secp256k1_recover::Secp256k1Pubkey;
+use solana_program::secp256k1_recover::{
+    secp256k1_recover, Secp256k1Pubkey, Secp256k1RecoverError,
+};
 
 pub fn convert_secp256k1pub_key_to_address(pubkey: &Secp256k1Pubkey) -> [u8; 20] {
     let mut address = [0u8; 20];
@@ -21,4 +23,43 @@ pub fn is_did_sol_prefix(did: &str) -> bool {
 
 pub fn check_other_controllers(controllers: &[String]) -> bool {
     controllers.iter().all(|did| !is_did_sol_prefix(did))
+}
+
+/// Returns the address that signed message producing signature.
+pub fn eth_verify_message(
+    message: &[u8],
+    nonce: u64,
+    signature: [u8; 64],
+    recovery_id: u8,
+) -> Result<Secp256k1Pubkey, Secp256k1RecoverError> {
+    let message_with_nonce = [message, nonce.to_le_bytes().as_ref()].concat();
+    // Ethereum conforming Message Input
+    // https://docs.ethers.io/v4/api-utils.html?highlight=hashmessage#hash-function-helpers
+    let sign_message_input = [
+        "\x19Ethereum Signed Message:\n".as_bytes(),
+        message_with_nonce.len().to_string().as_bytes(),
+        message_with_nonce.as_ref(),
+    ]
+    .concat();
+
+    let hash = keccak::hash(sign_message_input.as_ref());
+    // msg!("Hash: {:x?}", hash.as_ref());
+    // msg!("Message: {:x?}", message);
+    // msg!(
+    //     "sign_message_input: {:x?}, Length: {}",
+    //     sign_message_input,
+    //     sign_message_input.len()
+    // );
+    // msg!("Signature: {:x?}", raw_signature.signature);
+    // msg!("RecoveryId: {:x}", raw_signature.recovery_id);
+
+    let secp256k1_pubkey = secp256k1_recover(hash.as_ref(), recovery_id, signature.as_ref());
+    // msg!("Recovered: {:?}", secp256k1_pubkey.to_bytes());
+    //
+    // // Check EcdsaSecp256k1VerificationKey2019 matches
+    // msg!(
+    //     "Checking if {:x?} is an EcdsaSecp256k1VerificationKey2019 authority",
+    //     secp256k1_pubkey.to_bytes()
+    // );
+    secp256k1_pubkey
 }


### PR DESCRIPTION
- This allows to provide a cleaner interface to integrators.
```
    pub fn find_authority(
        &self,
        key: &[u8],
        filter_types: Option<&[VerificationMethodType]>,
        filter_fragment: Option<&String>,
    ) -> Option<&VerificationMethod> {
```
```
pub fn is_authority(
    did_account: &AccountInfo,
    did_account_seed_bump: Option<u8>,
    controlling_did_accounts: &[AccountInfo],
    key: &[u8],
    filter_types: Option<&[VerificationMethodType]>,
    filter_fragment: Option<&String>,
) -> Result<bool> {
```
- Internal constraint interface unchanged with
```
    pub fn find_authority_constraint(
        &self,
        sol_authority: &Pubkey,
        eth_message: &[u8],
        eth_raw_signature: Option<&Secp256k1RawSignature>,
        filter_fragment: Option<&String>,
    ) -> Option<&VerificationMethod> {
```