### PR TITLE
IDCOM-2012 Controller, docs and usability fixes

### DIFF
--- a/.github/workflows/did-io-driver.yml
+++ b/.github/workflows/did-io-driver.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v1

--- a/.github/workflows/dids-client-lib.yml
+++ b/.github/workflows/dids-client-lib.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v1

--- a/.github/workflows/sol-did.yml
+++ b/.github/workflows/sol-did.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Rust ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
@@ -28,7 +28,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache Solana version
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache
@@ -46,7 +46,7 @@ jobs:
           args: --manifest-path sol-did/Cargo.toml --all -- --check
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -60,7 +60,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Cache node dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ./sol-did/node_modules
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Rust ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
@@ -106,7 +106,7 @@ jobs:
           profile: minimal
 
       - name: Cache build dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -115,7 +115,7 @@ jobs:
           key: cargo-test-${{ hashFiles('sol-did/Cargo.lock') }}
 
       - name: Cache Solana version
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache
@@ -132,7 +132,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Cache node dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ./sol-did/node_modules
@@ -167,7 +167,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Rust ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
@@ -177,7 +177,7 @@ jobs:
           profile: minimal
 
       - name: Cache build dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -186,7 +186,7 @@ jobs:
           key: cargo-build-${{ hashFiles('sol-did/Cargo.lock') }}
 
       - name: Cache Solana version
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache
@@ -203,7 +203,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Cache node dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ./sol-did/node_modules
@@ -245,7 +245,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Rust ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
@@ -255,7 +255,7 @@ jobs:
           profile: minimal
 
       - name: Cache build dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -264,7 +264,7 @@ jobs:
           key: cargo-build-${{ hashFiles('sol-did/Cargo.lock') }}
 
       - name: Cache Solana version
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache
@@ -281,7 +281,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Cache node dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ./sol-did/node_modules

--- a/.github/workflows/sol-did.yml
+++ b/.github/workflows/sol-did.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: ['1.61']
-        solana: ['v1.13.5']
+        rust: ['stable']
+        solana: ['v1.14.7']
         os: [ubuntu-latest]
 
     steps:
@@ -90,8 +90,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: ['1.61']
-        solana: ['v1.13.5']
+        rust: ['stable']
+        solana: ['v1.14.7']
         os: [ubuntu-latest]
 
     steps:
@@ -162,7 +162,7 @@ jobs:
       matrix:
         node: [ '16.x' ]
         rust: ['stable']
-        solana: ['v1.13.5']
+        solana: ['v1.14.7']
         os: [ubuntu-latest]
 
     steps:
@@ -240,7 +240,7 @@ jobs:
       matrix:
         node: ['16.x']
         os: [ubuntu-latest]
-        solana: ['v1.13.5']
+        solana: ['v1.14.7']
         rust: ['stable']
 
     steps:

--- a/.github/workflows/uinresolver-driver.yml
+++ b/.github/workflows/uinresolver-driver.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v1

--- a/sol-did/README.md
+++ b/sol-did/README.md
@@ -2,20 +2,89 @@
 
 The [anchor-based](https://github.com/coral-xyz/anchor) program of `did:sol` on Solana.
 
-## is_authority Integration
-Other programs can check if a verification method (e.g. public key or address) by integrating `is_authority`:
+## Creating DIDs
+
+*Any Solana public key can be a DID.* This means that if you have a public key `abc`, then that key
+corresponds to the decentralized identifier `did:sol:abc`.
+
+This DID is called a `generative` DID, because it is generated from a public key, and has no other information associated with it.
+
+Generative DIDs have one authority, which is the public key itself (`abc` in this case).
+
+## Adding information to DIDs
+
+In order to add more authorities, or any other information to the DID, it must be initialised on chain,
+using the `initialize` instruction.
+
+Once a DID is initialized, other keys can be added to it using the `add_verification_method` instruction.
+
+## DID Accounts
+
+The information for a DID is stored on a `DID Account`, a PDA that is derived from the DID identifier.
+
+In order to derive the PDA for any DID, the following function is used:
+
+```rust
+use sol_did::integrations::derive_did_account;
+
+let (did_account, bump) = derive_did_account(key.to_bytes())
+```
+
+Where `key` is the identifier of the DID (`abc` in the above case)
+
+In order to reduce the amount of calculations that are needed to derive the DID account,
+you can pass the `bump` value as a parameter:
+
+```rust
+use sol_did::integrations::derive_did_account_with_bump;
+
+let did_account = derive_did_account_with_bump(key.to_bytes(), bump)?;
+```
+
+Note, in this case, the function returns a Result, in case the bump value is incorrect.
+
+## Checking if a key is an authority on a DID
+
+In order to use DIDs in your program, add the DID account to your instruction accounts list.
+
+The DID account is the that stores the DID information. Note: this can be `generative` (see above).
+
+To check if a key is an authority of a DID, use the `is_authority` instruction.
 
 ```rust
 use sol_did::integrations::is_authority;
+
+let signer_owns_did = is_authority(
+    &did_account,
+    None,
+    &[],
+    &signer.to_bytes(),
+    None,
+    None
+);
 ```
 
+This function works in the generative and non-generative case. In the generative case, the did_account
+must be owned by the system program.
+
+## Controller relationship
+
+One DID can be a `controller` of another DID.
+
+If a key `a` is an authority on `did:sol:abc`, and `did:sol:abc` is a controller of `did:sol:def`
+then the following `is_authority` relationship is true:
+
 ```rust
-// pub fn is_authority(did_account: &AccountInfo, 
-//                     did_account_seed_bump: Option<u8>, 
-//                     controlling_did_accounts: &[AccountInfo], 
-//                     key: &[u8], 
-//                     filter_types: Option<&[VerificationMethodType]>, 
-//                     filter_fragment: Option<&String>) -> Result<bool>
+use sol_did::integrations::is_authority;
+
+let signer_owns_did = is_authority(
+    &abc_account,
+    None,
+    &[(def_account_info, def)],
+    &abc.to_bytes(),
+    None,
+    None
+);
 ```
 
 ## Instructions

--- a/sol-did/programs/example/src/lib.rs
+++ b/sol-did/programs/example/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::result_large_err)]
 use anchor_lang::prelude::*;
 use sol_did_cpi::cpi::accounts::{AddService as CpiAddService, Initialize as CpiInitialize};
 use sol_did_cpi::cpi::{add_service as cpi_add_service, initialize as cpi_initialize};

--- a/sol-did/programs/sol-did/src/integrations/is_authority.rs
+++ b/sol-did/programs/sol-did/src/integrations/is_authority.rs
@@ -369,7 +369,7 @@ mod test {
         let controller_did_account_address = derive_did_account(&controller_authority.to_bytes());
         let controlled_did_account_address = derive_did_account(&controller_authority.to_bytes());
 
-        controlled_did_account.set_native_controllers(vec![controller_authority]);
+        controlled_did_account.set_native_controllers(vec![controller_authority]).unwrap();
 
         let mut controller_data: Vec<u8> = Vec::with_capacity(1024);
         controller_did_account
@@ -425,13 +425,12 @@ mod test {
 
         assert_ne!(controller_authority, controlled_authority);
 
-        let controller_did_account = create_test_did(controller_authority);
         let mut controlled_did_account = create_test_did(controlled_authority);
 
         let controller_did_account_address = derive_did_account(&controller_authority.to_bytes());
         let controlled_did_account_address = derive_did_account(&controller_authority.to_bytes());
 
-        controlled_did_account.set_native_controllers(vec![controller_authority]);
+        controlled_did_account.set_native_controllers(vec![controller_authority]).unwrap();
 
         let mut controller_data: Vec<u8> = Vec::with_capacity(0);
 

--- a/sol-did/programs/sol-did/src/integrations/is_authority.rs
+++ b/sol-did/programs/sol-did/src/integrations/is_authority.rs
@@ -369,7 +369,9 @@ mod test {
         let controller_did_account_address = derive_did_account(&controller_authority.to_bytes());
         let controlled_did_account_address = derive_did_account(&controller_authority.to_bytes());
 
-        controlled_did_account.set_native_controllers(vec![controller_authority]).unwrap();
+        controlled_did_account
+            .set_native_controllers(vec![controller_authority])
+            .unwrap();
 
         let mut controller_data: Vec<u8> = Vec::with_capacity(1024);
         controller_did_account
@@ -430,7 +432,9 @@ mod test {
         let controller_did_account_address = derive_did_account(&controller_authority.to_bytes());
         let controlled_did_account_address = derive_did_account(&controller_authority.to_bytes());
 
-        controlled_did_account.set_native_controllers(vec![controller_authority]).unwrap();
+        controlled_did_account
+            .set_native_controllers(vec![controller_authority])
+            .unwrap();
 
         let mut controller_data: Vec<u8> = Vec::with_capacity(0);
 

--- a/sol-did/programs/sol-did/src/integrations/mod.rs
+++ b/sol-did/programs/sol-did/src/integrations/mod.rs
@@ -1,3 +1,4 @@
 mod is_authority;
 
 pub use self::is_authority::is_authority;
+pub use self::is_authority::{derive_did_account, derive_did_account_with_bump};

--- a/sol-did/programs/sol-did/src/lib.rs
+++ b/sol-did/programs/sol-did/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! It exposes the public #program instructions, as well as integrations libraries that are
 //! independent of the anchor framework.
-
+#![allow(clippy::result_large_err)]
 #![warn(
 unused_import_braces,
 unused_imports,

--- a/sol-did/programs/sol-did/src/state/did_account.rs
+++ b/sol-did/programs/sol-did/src/state/did_account.rs
@@ -98,9 +98,9 @@ impl DidAccount {
 
     /// Return either the DidAccount inside the account or a default one derived from the pubkey
     pub fn try_from_or_default(
-        account_info_and_pubkey: &(AccountInfo, Pubkey),
+        account_info_and_pubkey: &(&AccountInfo, Pubkey),
     ) -> Result<DidAccount> {
-        Account::<DidAccount>::try_from(&account_info_and_pubkey.0)
+        Account::<DidAccount>::try_from(account_info_and_pubkey.0)
             .map(|account| Ok(account.into_inner()))
             .unwrap_or_else(|_| {
                 // return a default did_account if this is a generative DID
@@ -116,11 +116,6 @@ impl DidAccount {
                 require_keys_eq!(
                     System::id(),
                     *account_info_and_pubkey.0.owner,
-                    DidSolError::InvalidControllerChain
-                );
-                require_eq!(
-                    0u64,
-                    **account_info_and_pubkey.0.try_borrow_lamports().unwrap(),
                     DidSolError::InvalidControllerChain
                 );
                 Ok(DidAccount::default_for_key(&account_info_and_pubkey.1))


### PR DESCRIPTION
Change controller chain datatype to make it more usable.

Tuples containing accountInfo should contain references, as otherwise the datastructure is very difficult to generate in other programs.

I also exposed the utility functions derive_did_account and derive_did_account_with_bump, and added some docs.