### PR TITLE
IDCOM-2205 - client interface improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Allow to initialize `DidService` with a `did:` string
 
 ### Changed
+- Updated `updateFromDoc` to expect a generalized `DidDocument` and not a `DidSolDocument`
 
 ### Deprecated
 

--- a/sol-did/client/packages/cli/src/commands/resolve/index.ts
+++ b/sol-did/client/packages/cli/src/commands/resolve/index.ts
@@ -46,9 +46,7 @@ export default class Resolve extends Command {
   async run(): Promise<void> {
     const { args } = await this.parse(Resolve);
 
-    const didSolIdentifier = DidSolIdentifier.parse(args.didsol);
-
-    const service = DidSolService.build(didSolIdentifier);
+    const service = DidSolService.build(args.didsol);
 
     // console.log(`did:sol: ${service.did}`);
     // console.log(`did:sol PDA: ${service.didDataAccount.toBase58()}`);

--- a/sol-did/client/packages/core/src/DidSolIdentifier.ts
+++ b/sol-did/client/packages/core/src/DidSolIdentifier.ts
@@ -1,6 +1,10 @@
 import { PublicKey } from '@solana/web3.js';
 import { DecentralizedIdentifierConstructor } from './lib/types';
-import { findLegacyProgramAddress, findProgramAddress } from './lib/utils';
+import {
+  findLegacyProgramAddress,
+  findProgramAddress,
+  isStringDID,
+} from './lib/utils';
 import { DID_SOL_PREFIX } from './lib/const';
 import { VerificationMethod } from 'did-resolver';
 import { ExtendedCluster } from './lib/connection';
@@ -104,7 +108,7 @@ export class DidSolIdentifier {
    * @param did the did string
    */
   static parse(did: string | VerificationMethod): DidSolIdentifier {
-    if (typeof did === 'string') {
+    if (isStringDID(did)) {
       const matches = DidSolIdentifier.REGEX.exec(did);
 
       if (!matches) throw new Error('Invalid DID');

--- a/sol-did/client/packages/core/src/DidSolIdentifier.ts
+++ b/sol-did/client/packages/core/src/DidSolIdentifier.ts
@@ -104,7 +104,7 @@ export class DidSolIdentifier {
    * @param did the did string
    */
   static parse(did: string | VerificationMethod): DidSolIdentifier {
-    if (typeof did == 'string') {
+    if (typeof did === 'string') {
       const matches = DidSolIdentifier.REGEX.exec(did);
 
       if (!matches) throw new Error('Invalid DID');

--- a/sol-did/client/packages/core/src/DidSolService.ts
+++ b/sol-did/client/packages/core/src/DidSolService.ts
@@ -6,6 +6,7 @@ import {
   findLegacyProgramAddress,
   findProgramAddress,
   getBinarySize,
+  isStringDID,
   validateAndSplitControllers,
 } from './lib/utils';
 import {
@@ -43,10 +44,6 @@ import {
   DidSolEthSignStatusType,
   DidSolTransactionBuilder,
 } from './utils/DidSolTransactionBuilder';
-
-const isStringDID = (
-  identifier: DidSolIdentifier | string
-): identifier is string => typeof identifier === 'string';
 
 /**
  * The DidSolService class is a wrapper around the Solana DID program.

--- a/sol-did/client/packages/core/src/DidSolService.ts
+++ b/sol-did/client/packages/core/src/DidSolService.ts
@@ -44,6 +44,8 @@ import {
   DidSolTransactionBuilder,
 } from './utils/DidSolTransactionBuilder';
 
+const isStringDID = (identifier: DidSolIdentifier | string): identifier is string => typeof identifier === 'string';
+
 /**
  * The DidSolService class is a wrapper around the Solana DID program.
  * It provides methods for creating, reading, updating, and deleting DID documents.
@@ -56,9 +58,14 @@ export class DidSolService extends DidSolTransactionBuilder {
   private readonly _legacyDidDataAccount: PublicKey;
 
   static build(
-    identifier: DidSolIdentifier,
+    identifier: DidSolIdentifier | string,
     options: DidSolServiceOptions = {}
   ): DidSolService {
+    // if identifier is a string, parse it
+    if (isStringDID(identifier)) {
+      identifier = DidSolIdentifier.parse(identifier);
+    }
+
     const wallet = options.wallet || new NonSigningWallet();
     const confirmOptions =
       options.confirmOptions || AnchorProvider.defaultOptions();
@@ -85,10 +92,15 @@ export class DidSolService extends DidSolTransactionBuilder {
 
   static buildFromAnchor(
     program: Program<SolDid>,
-    identifier: DidSolIdentifier,
+    identifier: DidSolIdentifier | string,
     provider: AnchorProvider,
     wallet?: Wallet
   ): DidSolService {
+    // if identifier is a string, parse it
+    if (isStringDID(identifier)) {
+      identifier = DidSolIdentifier.parse(identifier);
+    }
+
     return new DidSolService(
       program,
       identifier.authority,

--- a/sol-did/client/packages/core/src/DidSolService.ts
+++ b/sol-did/client/packages/core/src/DidSolService.ts
@@ -44,7 +44,9 @@ import {
   DidSolTransactionBuilder,
 } from './utils/DidSolTransactionBuilder';
 
-const isStringDID = (identifier: DidSolIdentifier | string): identifier is string => typeof identifier === 'string';
+const isStringDID = (
+  identifier: DidSolIdentifier | string
+): identifier is string => typeof identifier === 'string';
 
 /**
  * The DidSolService class is a wrapper around the Solana DID program.
@@ -564,7 +566,7 @@ export class DidSolService extends DidSolTransactionBuilder {
       );
     }
 
-    const didSolDocument = DidSolDocument.fromDoc(document)
+    const didSolDocument = DidSolDocument.fromDoc(document);
 
     const updateArgs = didSolDocument.getDocUpdateArgs();
     return this.update(updateArgs, authority);

--- a/sol-did/client/packages/core/src/DidSolService.ts
+++ b/sol-did/client/packages/core/src/DidSolService.ts
@@ -555,7 +555,7 @@ export class DidSolService extends DidSolTransactionBuilder {
    * @param authority The authority to use. Can be "wrong" if instruction is later signed with ethSigner
    */
   updateFromDoc(
-    document: DidSolDocument,
+    document: DIDDocument,
     authority: PublicKey = this._wallet.publicKey
   ): DidSolService {
     if (document.id !== this.did) {
@@ -564,7 +564,9 @@ export class DidSolService extends DidSolTransactionBuilder {
       );
     }
 
-    const updateArgs = document.getDocUpdateArgs();
+    const didSolDocument = DidSolDocument.fromDoc(document)
+
+    const updateArgs = didSolDocument.getDocUpdateArgs();
     return this.update(updateArgs, authority);
   }
 

--- a/sol-did/client/packages/core/src/lib/utils.ts
+++ b/sol-did/client/packages/core/src/lib/utils.ts
@@ -5,6 +5,7 @@ import { Keypair, PublicKey, TransactionInstruction } from '@solana/web3.js';
 import { getAddress } from '@ethersproject/address';
 import { hexlify, arrayify } from '@ethersproject/bytes';
 import { decode } from 'bs58';
+import { VerificationMethod as ResolverVerificationMethod } from 'did-resolver';
 
 import {
   Bytes,
@@ -293,3 +294,7 @@ export const getKeyDataFromVerificationMethod = (
       throw new Error(`Verification method type '${vm.type}' not recognized`);
   }
 };
+
+export const isStringDID = (
+  identifier: ResolverVerificationMethod | DidSolIdentifier | string
+): identifier is string => typeof identifier === 'string';


### PR DESCRIPTION
### Added
- Allow to initialize `DidService` with a `did:` string

### Changed
- Updated `updateFromDoc` to expect a generalized `DidDocument` and not a `DidSolDocument`