### PR TITLE
Fix: Prevent Lockout on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Prevent Lockout on generalized `update()` function
 
 ### Security
 
@@ -31,7 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-- Prevent Lockout on generalized `update()` function
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Prevent Lockout on generalized `update()` function
 
 ### Security
 

--- a/sol-did/programs/sol-did/src/instructions/update.rs
+++ b/sol-did/programs/sol-did/src/instructions/update.rs
@@ -1,3 +1,4 @@
+use crate::errors::DidSolError;
 use crate::state::{DidAccount, Secp256k1RawSignature};
 use crate::{Service, VerificationMethod};
 use anchor_lang::prelude::*;
@@ -17,6 +18,12 @@ pub fn update(
     data.set_verification_methods(Vec::new(), update_arg.verification_methods)?;
     data.set_native_controllers(update_arg.native_controllers)?;
     data.set_other_controllers(update_arg.other_controllers)?;
+
+    // prevent lockout
+    require!(
+        data.has_authority_verification_methods(),
+        DidSolError::VmCannotRemoveLastAuthority
+    );
 
     Ok(())
 }

--- a/sol-did/tests/suite-auth/auth.ts
+++ b/sol-did/tests/suite-auth/auth.ts
@@ -480,4 +480,23 @@ describe('sol-did auth operations', () => {
         'Error Message: Removing the last verification method would lead to a lockout.'
     );
   });
+
+  it('cannot use update to remove all VerificationMethods with a CapabilityInvocation', async () => {
+    return expect(
+      service
+        .update(
+          {
+            services: [],
+            controllerDIDs: [],
+            verificationMethods: [],
+          },
+          newSolKey.publicKey
+        )
+        .withPartialSigners(newSolKey)
+        .rpc()
+    ).to.be.rejectedWith(
+      'Error Code: VmCannotRemoveLastAuthority. Error Number: 6003. ' +
+        'Error Message: Removing the last verification method would lead to a lockout.'
+    );
+  });
 });


### PR DESCRIPTION
Fix a bug where a user could remove all VerificationMethods on `update()`