### PR TITLE
otherControllers MUST be did's, but cannot be did:sol's

### DIFF
--- a/sol-did/programs/sol-did/src/constants.rs
+++ b/sol-did/programs/sol-did/src/constants.rs
@@ -1,3 +1,4 @@
 pub const DID_ACCOUNT_SEED: &str = "did-account";
+pub const DID_PREFIX: &str = "did:";
 pub const DID_SOL_PREFIX: &str = "did:sol:";
 pub const VM_DEFAULT_FRAGMENT_NAME: &str = "default";

--- a/sol-did/programs/sol-did/src/utils.rs
+++ b/sol-did/programs/sol-did/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::constants::DID_SOL_PREFIX;
+use crate::constants::{DID_PREFIX, DID_SOL_PREFIX};
 use crate::{id, DID_ACCOUNT_SEED};
 use anchor_lang::prelude::{Error, ErrorCode};
 use solana_program::keccak;
@@ -17,8 +17,14 @@ pub fn is_did_sol_prefix(did: &str) -> bool {
     did.starts_with(DID_SOL_PREFIX)
 }
 
+pub fn is_did_prefix(did: &str) -> bool {
+    did.starts_with(DID_PREFIX)
+}
+
 pub fn check_other_controllers(controllers: &[String]) -> bool {
-    controllers.iter().all(|did| !is_did_sol_prefix(did))
+    controllers
+        .iter()
+        .all(|did| is_did_prefix(did) && !is_did_sol_prefix(did))
 }
 
 /// Returns the address that signed message producing signature.


### PR DESCRIPTION
So far, only the client guaranteed that otherControllers have the correct `did:` prefix. Now, also the program verifies this check correctly.

Extended test (that do not use the client) for this case.